### PR TITLE
Prevent overwrite of sigint handler

### DIFF
--- a/python/blickfeld_scanner/stream/point_cloud.py
+++ b/python/blickfeld_scanner/stream/point_cloud.py
@@ -27,9 +27,12 @@ import sys
 
 terminate = False
 
+original_sigint_handler = signal.getsignal(signal.SIGINT)
+
 def signal_handler(sig, frame):
     global terminate
     terminate = True
+    original_sigint_handler(sig, frame)
 
 # Catch CTRL-C and terminate and close the point cloud stream
 signal.signal(signal.SIGINT, signal_handler)


### PR DESCRIPTION
This commit prevents that the SIGINT handler is overwritten by the
blickfeld scanner library. It will call the original signint handler.

The problem arises if the scanner library is used in e.g. an asyncio loop.
Then the CancelledError is not called, because the SIGINT is already caught by the blickfeld scanner library.